### PR TITLE
Output correct HTML entity for \r{a}

### DIFF
--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -879,7 +879,7 @@ function latex2html($line) {
   $line = char2html($line,'^','o',"circ");
   $line = char2html($line,'^','u',"circ");
 
-  $line = char2html($line,'.','a',"ring");
+  $line = char2html($line,'r','a',"ring");
 
   $line = char2html($line,'c','c',"cedil");
   $line = char2html($line,'v','s',"caron");


### PR DESCRIPTION
There is an issue with characters å and Å (with ring above). The corresponding HTML entities are `&aring;` / `&Aring;`

To get this character with latex we'd do: `\r{a}` or `\aa`

With bibtextbrowser `\aa` works fine. However, `\r{a}` doesn't do anything at all. This pull fixes this, we now output the correct HTML for `\r{a}` and `\r{A}`.

Furthermore, up till now bibtexbrowser will output `&aring;` if it encounters `\.{a}`, but this is wrong since this latex is meant to be used to produce an overdot (dot above char) and not "ring above char". Since in practice this is a "spelling error", this behaviour is removed and from now on `\.{a}` will not get replaced.
