### PR TITLE
Fixes a potential cross site scripting (XSS) issue

### DIFF
--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -238,15 +238,14 @@ function _zetDB($bibtex_filenames) {
 
   // ---------------------------- HANDLING unexistent files
   foreach(explode(MULTIPLE_BIB_SEPARATOR, $bibtex_filenames) as $bib) {
-    // escape $bib to prevent XSS
-  	$escapedBib = htmlEntities($bib, ENT_QUOTES);
     // get file extension to only allow .bib files
-    $ext = pathinfo($escapedBib, PATHINFO_EXTENSION);
+    $ext = pathinfo($bib, PATHINFO_EXTENSION);
     // this is a security protection
-    if (BIBTEXBROWSER_LOCAL_BIB_ONLY && (!file_exists($escapedBib) || strcasecmp($ext, 'bib') != 0)) {
-
+    if (BIBTEXBROWSER_LOCAL_BIB_ONLY && (!file_exists($bib) || strcasecmp($ext, 'bib') != 0)) {
      // to automate dectection of faulty links with tools such as webcheck
      header('HTTP/1.1 404 Not found');
+    // escape $bib to prevent XSS
+  	$escapedBib = htmlEntities($bib, ENT_QUOTES);
      die('<b>the bib file '.$escapedBib.' does not exist !</b>');
     }
   } // end for each


### PR DESCRIPTION
e.g. something like this should not be possible:
http://bibtexbrowser.sourceforge.net/bibtexbrowser.php?bib=%3Cscript%3Ealert%2842%29%3C/script%3E
