### PR TITLE
prevent collision if i18n function already exists

### DIFF
--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -353,12 +353,14 @@ function _zetDB($bibtex_filenames) {
 } // end function setDB
 
 // internationalization
-function __($msg) {
-  global $BIBTEXBROWSER_LANG;
-  if (isset($BIBTEXBROWSER_LANG[$msg])) { 
-    return $BIBTEXBROWSER_LANG[$msg]; 
+if (!function_exists('__')){
+  function __($msg) {
+    global $BIBTEXBROWSER_LANG;
+    if (isset($BIBTEXBROWSER_LANG[$msg])) {
+      return $BIBTEXBROWSER_LANG[$msg];
+    }
+    return $msg;
   }
-  return $msg;
 }
 
 // factories


### PR DESCRIPTION
Currently, attempting to insert bibtexbrowser into a setting where `__()` exists (such as wordpress for example) results in `Fatal error: Cannot redeclare __()`. 
This fix creates the function only if it does not exist yet. 
If it does exist, bibtexbrowser will use the existing version instead.
