### PR TITLE
Fixing a bug where ajax wouldn't grab whole document in case there was ampersands in link.

### DIFF
--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -2160,7 +2160,7 @@ $('a.biburl').each(function() { // for each url "[bibtex]"
     ev.preventDefault(); // no open url
     if (biburl.nextAll('pre').length == 0) { // we don't have yet the bibtex data
       var bibtexEntryUrl = $(this).attr('href');
-      $.ajax({url: bibtexEntryUrl,  dataType: 'xml', success: function (data) { // we download it
+      $.ajax({url: bibtexEntryUrl,  dataType: 'html', success: function (data) { // we download it
         // elem is the element containing bibtex entry, creating a new element is required for Chrome and IE
         var elem = $('<pre class="purebibtex"/>');         
         elem.text($('.purebibtex', data).text()); // both text() are required for IE


### PR DESCRIPTION
The ajax request is being sent to html page hence you should use html as data type. Using xml might break in case there is un-escaped characters such as "<" or "&" in html. In fact it was causing problems when trying to retrieve bibtex data for particular item which included link with an ampersand.

It was mentioned in comments section in website by Tobi:

> Tobi: Hi Martin, 
> 
> it seems like bibtexbrowser cannot handle & (ampersands) in URLs. Entries that contain & confuse > the bibtex-block-script, which displays bibtex information in a new site instead of loading the > block of information just below the entry. I can't seem to find the bug, but hope that you can. 
> 
> Tobi
> (May 27, 2014 - 6:33 pm)

Also I have found some random page which is using bibtexbrowser and you can see the bug here http://www.imp.kiev.ua/~kord/papers/ by clicking on "Strong electron pairing at the iron 3dxz,yz orbitals in hole-doped BaFe2As2 superconductors revealed by angle-resolved photoemission spectroscopy" article's bib anchor.
