### PR TITLE
Bibtex entry URL: removed too specific comment

### DIFF
--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -2489,7 +2489,7 @@ $('a.biburl').each(function() { // for each url "[bibtex]"
         var elem = $('<pre class="purebibtex"/>');
         elem.text($('.purebibtex', data).text()); // both text() are required for IE
         // we add a link so that users clearly see that even with AJAX
-        // there is still one URL per paper (which is important for crawlers and metadata)
+        // there is still one URL per paper.
         elem.append(
            $('<div>%% Bibtex entry URL: <a href="'+bibtexEntryUrl+'">'+bibtexEntryUrl+'</a></div>')
            ).appendTo(biburl.parent());


### PR DESCRIPTION
AFAIK, crawlers usually do not use JavaScript or AJAX, so I removed that argument as a reason.
Also, the URL that is inserted is not metadata in terms of a HTML document so I removed that argument as well.