### PR TITLE
protocol-relative loading of jQuery library

### DIFF
--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -2474,7 +2474,7 @@ function poweredby() {
 function javascript() {
   // we use jquery with the official content delivery URLs
   // Microsoft and Google also provide jquery with their content delivery networks
-?><script type="text/javascript" src="http://code.jquery.com/jquery-1.5.1.min.js"></script>
+?><script type="text/javascript" src="//code.jquery.com/jquery-1.5.1.min.js"></script>
 <script type="text/javascript" ><!--
 // Javascript progressive enhancement for bibtexbrowser
 $('a.biburl').each(function() { // for each url "[bibtex]"


### PR DESCRIPTION
Browsers reject to load non-SSL content into a SSL-secured site (i.e. when BibTexBrowser is loaded via SSL).
This currently leads to a inconsistent behavior between SSL and non-SSL secured BibTexBrowser sites since the jQuery library won't loaded.
This "patch" fixes this problem by advising the browser to use the same protocol to load jQuery as used for the site itself.