### PR TITLE
added composer script for builtin server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,8 @@
     ],
     "require": {
 	"php": ">=4"
+    },
+    "scripts": {
+        "serve": ["@php -S localhost:8080 bibtexbrowser.php"]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
 	"php": ">=4"
     },
     "scripts": {
-        "serve": ["@php -S localhost:8080 bibtexbrowser.php"]
+        "serve": ["@php -S localhost:29896 bibtexbrowser.php"]
     }
 }


### PR DESCRIPTION
So, this does work, but still requires the user to manually append `?bib=whatever.bib` to `localhost:29896`.

EDIT: This requires PHP version, I think, >=5.4.