### PR TITLE
Add Havek C (UTF-8 268/269) conversion to latex2html

### DIFF
--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -1075,6 +1075,9 @@ function latex2html($line, $do_clean_extra_bracket=true) {
   $line = str_replace('\\k{a}','&#261',$line);
   $line = str_replace('\\\'{c}','&#263',$line);
 
+  $line = str_replace('\\v{c}','&#269',$line);
+  $line = str_replace('\\v{C}','&#268',$line);
+
   if ($do_clean_extra_bracket) {
     // clean extra tex curly brackets, usually used for preserving capitals
     // must come before the final math replacement


### PR DESCRIPTION
See symbols-a4.pdf, e.g., page 20 ("Text mode accents"), where \v{ } is listed. 

I just added the conversion for 'c' and 'C'. I'm no expert with UTF-8, so if anybody has a good idea to generalize that conversion... :)