### PR TITLE
added support for Oxford commas in name lists

### DIFF
--- a/bibtexbrowser-test.php
+++ b/bibtexbrowser-test.php
@@ -486,7 +486,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
 
     function test_formatting() {
 
-        $bibtex = "@article{aKey61,title={An article Book},author = {Meyer, Heribert  and   {Advanced Air and Ground Research Team} and Foo Bar}}\n";
+        $bibtex = "@article{aKey61,title={An article Book},author = {Meyer, Heribert  and   {Advanced Air and Ground Research Team} and Foo Bar}}\n@article{bKey61,title={An article Book},author = {Meyer, Heribert and Foo Bar}}\n";
         $test_data = fopen('php://memory','x+');
         fwrite($test_data, $bibtex);
         fseek($test_data,0);
@@ -500,7 +500,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals("Meyer, Heribert", $authors[0]);
         $this->assertEquals("Advanced Air and Ground Research Team", $authors[1]);
         $this->assertEquals("Foo Bar", $authors[2]);
-        $this->assertEquals("Meyer, Heribert, Advanced Air and Ground Research Team and Foo Bar", $entry->getFormattedAuthorsString());
+        $this->assertEquals("Meyer, Heribert, Advanced Air and Ground Research Team,  and Foo Bar", $entry->getFormattedAuthorsString());
 
         // test with formatting (first name before)
         bibtexbrowser_configure('USE_COMMA_AS_NAME_SEPARATOR_IN_OUTPUT', true);
@@ -509,7 +509,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals("Meyer, Heribert", $authors[0]);
         $this->assertEquals("Team, Advanced Air and Ground Research", $authors[1]);
         $this->assertEquals("Bar, Foo", $authors[2]);
-        $this->assertEquals("Meyer, Heribert; Team, Advanced Air and Ground Research and Bar, Foo", $entry->getFormattedAuthorsString());
+        $this->assertEquals("Meyer, Heribert; Team, Advanced Air and Ground Research;  and Bar, Foo", $entry->getFormattedAuthorsString());
 
         // test with formatting (with initials) formatAuthorInitials
         bibtexbrowser_configure('USE_COMMA_AS_NAME_SEPARATOR_IN_OUTPUT', false);
@@ -519,7 +519,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals("Meyer H", $authors[0]);
         $this->assertEquals("Team AAand GR", $authors[1]);
         $this->assertEquals("Bar F", $authors[2]);
-        $this->assertEquals("Meyer H, Team AAand GR and Bar F", $entry->getFormattedAuthorsString());
+        $this->assertEquals("Meyer H, Team AAand GR,  and Bar F", $entry->getFormattedAuthorsString());
 
         // test with first_name last_name formatAuthorCanonical
         bibtexbrowser_configure('USE_COMMA_AS_NAME_SEPARATOR_IN_OUTPUT', false);
@@ -530,8 +530,14 @@ class BTBTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals("Heribert Meyer", $authors[0]);
         $this->assertEquals("Advanced Air and Ground Research Team", $authors[1]);
         $this->assertEquals("Foo Bar", $authors[2]);
-        $this->assertEquals("Heribert Meyer, Advanced Air and Ground Research Team and Foo Bar", $entry->getFormattedAuthorsString());
-
+        $this->assertEquals("Heribert Meyer, Advanced Air and Ground Research Team,  and Foo Bar", $entry->getFormattedAuthorsString());
+        
+        // test there is no Oxford comma for only two authors with default options
+        bibtexbrowser_configure('USE_COMMA_AS_NAME_SEPARATOR_IN_OUTPUT', false);
+        bibtexbrowser_configure('USE_INITIALS_FOR_NAMES', false);
+        bibtexbrowser_configure('USE_FIRST_THEN_LAST', false);
+        $entry = $db->getEntryByKey('bKey61');
+        $this->assertEquals("Meyer, Heribert and Foo Bar", $entry->getFormattedAuthorsString());
     }
 
     function test_parsing_author_list() {
@@ -760,11 +766,11 @@ class BTBTest extends PHPUnit_Framework_TestCase {
         $btb->load('bibacid-utf8.bib');
         $this->assertEquals(4,count($btb->bibdb['arXiv-1807.05030']->getRawAuthors()));
         $this->assertEquals(4,count($btb->bibdb['arXiv-1807.05030']->getFormattedAuthorsArray()));
-        $this->assertEquals("Oscar Luis Vera-Pérez, Benjamin Danglot, Martin Monperrus and Benoit Baudry",$btb->bibdb['arXiv-1807.05030']->getAuthor());
+        $this->assertEquals("Oscar Luis Vera-Pérez, Benjamin Danglot, Martin Monperrus,  and Benoit Baudry",$btb->bibdb['arXiv-1807.05030']->getAuthor());
 
         bibtexbrowser_configure('BIBTEXBROWSER_LINK_STYLE','nothing');
         bibtexbrowser_configure('BIBLIOGRAPHYSTYLE','JanosBibliographyStyle');
-        $this->assertEquals("Oscar Luis Vera-Pérez, Benjamin Danglot, Martin Monperrus and Benoit Baudry,  \"A Comprehensive Study of Pseudo-tested Methods\", Technical report, arXiv 1807.05030, 2018.\n ",strip_tags($btb->bibdb['arXiv-1807.05030']->toHTML()));
+        $this->assertEquals("Oscar Luis Vera-Pérez, Benjamin Danglot, Martin Monperrus,  and Benoit Baudry,  \"A Comprehensive Study of Pseudo-tested Methods\", Technical report, arXiv 1807.05030, 2018.\n ",strip_tags($btb->bibdb['arXiv-1807.05030']->toHTML()));
 
     }
 

--- a/bibtexbrowser-test.php
+++ b/bibtexbrowser-test.php
@@ -500,7 +500,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals("Meyer, Heribert", $authors[0]);
         $this->assertEquals("Advanced Air and Ground Research Team", $authors[1]);
         $this->assertEquals("Foo Bar", $authors[2]);
-        $this->assertEquals("Meyer, Heribert, Advanced Air and Ground Research Team,  and Foo Bar", $entry->getFormattedAuthorsString());
+        $this->assertEquals("Meyer, Heribert, Advanced Air and Ground Research Team, and Foo Bar", $entry->getFormattedAuthorsString());
 
         // test with formatting (first name before)
         bibtexbrowser_configure('USE_COMMA_AS_NAME_SEPARATOR_IN_OUTPUT', true);
@@ -509,7 +509,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals("Meyer, Heribert", $authors[0]);
         $this->assertEquals("Team, Advanced Air and Ground Research", $authors[1]);
         $this->assertEquals("Bar, Foo", $authors[2]);
-        $this->assertEquals("Meyer, Heribert; Team, Advanced Air and Ground Research;  and Bar, Foo", $entry->getFormattedAuthorsString());
+        $this->assertEquals("Meyer, Heribert; Team, Advanced Air and Ground Research; and Bar, Foo", $entry->getFormattedAuthorsString());
 
         // test with formatting (with initials) formatAuthorInitials
         bibtexbrowser_configure('USE_COMMA_AS_NAME_SEPARATOR_IN_OUTPUT', false);
@@ -519,7 +519,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals("Meyer H", $authors[0]);
         $this->assertEquals("Team AAand GR", $authors[1]);
         $this->assertEquals("Bar F", $authors[2]);
-        $this->assertEquals("Meyer H, Team AAand GR,  and Bar F", $entry->getFormattedAuthorsString());
+        $this->assertEquals("Meyer H, Team AAand GR, and Bar F", $entry->getFormattedAuthorsString());
 
         // test with first_name last_name formatAuthorCanonical
         bibtexbrowser_configure('USE_COMMA_AS_NAME_SEPARATOR_IN_OUTPUT', false);
@@ -530,7 +530,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals("Heribert Meyer", $authors[0]);
         $this->assertEquals("Advanced Air and Ground Research Team", $authors[1]);
         $this->assertEquals("Foo Bar", $authors[2]);
-        $this->assertEquals("Heribert Meyer, Advanced Air and Ground Research Team,  and Foo Bar", $entry->getFormattedAuthorsString());
+        $this->assertEquals("Heribert Meyer, Advanced Air and Ground Research Team, and Foo Bar", $entry->getFormattedAuthorsString());
         
         // test there is no Oxford comma for only two authors with default options
         bibtexbrowser_configure('USE_COMMA_AS_NAME_SEPARATOR_IN_OUTPUT', false);
@@ -766,11 +766,11 @@ class BTBTest extends PHPUnit_Framework_TestCase {
         $btb->load('bibacid-utf8.bib');
         $this->assertEquals(4,count($btb->bibdb['arXiv-1807.05030']->getRawAuthors()));
         $this->assertEquals(4,count($btb->bibdb['arXiv-1807.05030']->getFormattedAuthorsArray()));
-        $this->assertEquals("Oscar Luis Vera-Pérez, Benjamin Danglot, Martin Monperrus,  and Benoit Baudry",$btb->bibdb['arXiv-1807.05030']->getAuthor());
+        $this->assertEquals("Oscar Luis Vera-Pérez, Benjamin Danglot, Martin Monperrus, and Benoit Baudry",$btb->bibdb['arXiv-1807.05030']->getAuthor());
 
         bibtexbrowser_configure('BIBTEXBROWSER_LINK_STYLE','nothing');
         bibtexbrowser_configure('BIBLIOGRAPHYSTYLE','JanosBibliographyStyle');
-        $this->assertEquals("Oscar Luis Vera-Pérez, Benjamin Danglot, Martin Monperrus,  and Benoit Baudry,  \"A Comprehensive Study of Pseudo-tested Methods\", Technical report, arXiv 1807.05030, 2018.\n ",strip_tags($btb->bibdb['arXiv-1807.05030']->toHTML()));
+        $this->assertEquals("Oscar Luis Vera-Pérez, Benjamin Danglot, Martin Monperrus, and Benoit Baudry,  \"A Comprehensive Study of Pseudo-tested Methods\", Technical report, arXiv 1807.05030, 2018.\n ",strip_tags($btb->bibdb['arXiv-1807.05030']->toHTML()));
 
     }
 

--- a/bibtexbrowser-test.php
+++ b/bibtexbrowser-test.php
@@ -772,7 +772,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
 
         bibtexbrowser_configure('BIBTEXBROWSER_LINK_STYLE','nothing');
         bibtexbrowser_configure('BIBLIOGRAPHYSTYLE','JanosBibliographyStyle');
-        $this->assertEquals("Oscar Luis Vera-Pérez, Benjamin Danglot, Martin Monperrus, and Benoit Baudry,  \"A Comprehensive Study of Pseudo-tested Methods\", Technical report, arXiv 1807.05030, 2018.\n ",strip_tags($btb->bibdb['arXiv-1807.05030']->toHTML()));
+        $this->assertEquals("Oscar Luis Vera-Pérez, Benjamin Danglot, Martin Monperrus and Benoit Baudry,  \"A Comprehensive Study of Pseudo-tested Methods\", Technical report, arXiv 1807.05030, 2018.\n ",strip_tags($btb->bibdb['arXiv-1807.05030']->toHTML()));
 
     }
 

--- a/bibtexbrowser-test.php
+++ b/bibtexbrowser-test.php
@@ -768,7 +768,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
         $btb->load('bibacid-utf8.bib');
         $this->assertEquals(4,count($btb->bibdb['arXiv-1807.05030']->getRawAuthors()));
         $this->assertEquals(4,count($btb->bibdb['arXiv-1807.05030']->getFormattedAuthorsArray()));
-        $this->assertEquals("Oscar Luis Vera-Pérez, Benjamin Danglot, Martin Monperrus, and Benoit Baudry",$btb->bibdb['arXiv-1807.05030']->getAuthor());
+        $this->assertEquals("Oscar Luis Vera-Pérez, Benjamin Danglot, Martin Monperrus and Benoit Baudry",$btb->bibdb['arXiv-1807.05030']->getAuthor());
 
         bibtexbrowser_configure('BIBTEXBROWSER_LINK_STYLE','nothing');
         bibtexbrowser_configure('BIBLIOGRAPHYSTYLE','JanosBibliographyStyle');

--- a/bibtexbrowser-test.php
+++ b/bibtexbrowser-test.php
@@ -500,7 +500,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals("Meyer, Heribert", $authors[0]);
         $this->assertEquals("Advanced Air and Ground Research Team", $authors[1]);
         $this->assertEquals("Foo Bar", $authors[2]);
-        $this->assertEquals("Meyer, Heribert, Advanced Air and Ground Research Team, and Foo Bar", $entry->getFormattedAuthorsString());
+        $this->assertEquals("Meyer, Heribert, Advanced Air and Ground Research Team and Foo Bar", $entry->getFormattedAuthorsString());
 
         // test with formatting (first name before)
         bibtexbrowser_configure('USE_COMMA_AS_NAME_SEPARATOR_IN_OUTPUT', true);
@@ -509,7 +509,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals("Meyer, Heribert", $authors[0]);
         $this->assertEquals("Team, Advanced Air and Ground Research", $authors[1]);
         $this->assertEquals("Bar, Foo", $authors[2]);
-        $this->assertEquals("Meyer, Heribert; Team, Advanced Air and Ground Research; and Bar, Foo", $entry->getFormattedAuthorsString());
+        $this->assertEquals("Meyer, Heribert; Team, Advanced Air and Ground Research and Bar, Foo", $entry->getFormattedAuthorsString());
 
         // test with formatting (with initials) formatAuthorInitials
         bibtexbrowser_configure('USE_COMMA_AS_NAME_SEPARATOR_IN_OUTPUT', false);
@@ -519,7 +519,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals("Meyer H", $authors[0]);
         $this->assertEquals("Team AAand GR", $authors[1]);
         $this->assertEquals("Bar F", $authors[2]);
-        $this->assertEquals("Meyer H, Team AAand GR, and Bar F", $entry->getFormattedAuthorsString());
+        $this->assertEquals("Meyer H, Team AAand GR and Bar F", $entry->getFormattedAuthorsString());
 
         // test with first_name last_name formatAuthorCanonical
         bibtexbrowser_configure('USE_COMMA_AS_NAME_SEPARATOR_IN_OUTPUT', false);
@@ -530,12 +530,14 @@ class BTBTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals("Heribert Meyer", $authors[0]);
         $this->assertEquals("Advanced Air and Ground Research Team", $authors[1]);
         $this->assertEquals("Foo Bar", $authors[2]);
-        $this->assertEquals("Heribert Meyer, Advanced Air and Ground Research Team, and Foo Bar", $entry->getFormattedAuthorsString());
+        $this->assertEquals("Heribert Meyer, Advanced Air and Ground Research Team and Foo Bar", $entry->getFormattedAuthorsString());
         
-        // test there is no Oxford comma for only two authors with default options
+        // test Oxford comma with default options
         bibtexbrowser_configure('USE_COMMA_AS_NAME_SEPARATOR_IN_OUTPUT', false);
         bibtexbrowser_configure('USE_INITIALS_FOR_NAMES', false);
         bibtexbrowser_configure('USE_FIRST_THEN_LAST', false);
+        bibtexbrowser_configure('USE_OXFORD_COMMA', true);
+        $this->assertEquals("Meyer, Heribert, Advanced Air and Ground Research Team, and Foo Bar", $entry->getFormattedAuthorsString());
         $entry = $db->getEntryByKey('bKey61');
         $this->assertEquals("Meyer, Heribert and Foo Bar", $entry->getFormattedAuthorsString());
     }

--- a/bibtexbrowser-test.php
+++ b/bibtexbrowser-test.php
@@ -540,6 +540,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals("Meyer, Heribert, Advanced Air and Ground Research Team, and Foo Bar", $entry->getFormattedAuthorsString());
         $entry = $db->getEntryByKey('bKey61');
         $this->assertEquals("Meyer, Heribert and Foo Bar", $entry->getFormattedAuthorsString());
+        bibtexbrowser_configure('USE_OXFORD_COMMA', false);
     }
 
     function test_parsing_author_list() {

--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -1571,8 +1571,10 @@ class BibEntry {
       $result .= $authors[$i].$sep;
     }
     $lastAuthorSeperator = bibtexbrowser_configuration('LAST_AUTHOR_SEPARATOR');
+    // add Oxford comma if there are more than 2 authors
     if (count($authors)>2) {
       $lastAuthorSeperator = $sep.$lastAuthorSeperator;
+      $lastAuthorSeperator = preg_replace("/ {2,}/", " ", $lastAuthorSeperator);
     }
     $result .= $authors[count($authors)-2].$lastAuthorSeperator.$authors[count($authors)-1];
     return $result;

--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -170,7 +170,8 @@ if (defined('ENCODING')) {
 @define('USE_INITIALS_FOR_NAMES',false); // use only initials for all first names?
 @define('USE_FIRST_THEN_LAST',false); // put first names before last names?
 @define('FORCE_NAMELIST_SEPARATOR', ''); // if non-empty, use this to separate multiple names regardless of USE_COMMA_AS_NAME_SEPARATOR_IN_OUTPUT
-@define('LAST_AUTHOR_SEPARATOR',' and '); // if there are more than 2 names, an Oxford comma will be used
+@define('LAST_AUTHOR_SEPARATOR',' and ');
+@define('USE_OXFORD_COMMA',false); // adds an additional separator in addition to LAST_AUTHOR_SEPARATOR if there are more than two authors
 
 @define('TYPES_SIZE',10); // number of entry types per table
 @define('YEAR_SIZE',20); // number of years per table
@@ -1572,9 +1573,9 @@ class BibEntry {
     }
     $lastAuthorSeperator = bibtexbrowser_configuration('LAST_AUTHOR_SEPARATOR');
     // add Oxford comma if there are more than 2 authors
-    if (count($authors)>2) {
+    if (bibtexbrowser_configuration('USE_OXFORD_COMMA') && count($authors)>2) {
       $lastAuthorSeperator = $sep.$lastAuthorSeperator;
-      $lastAuthorSeperator = preg_replace("/ {2,}/", " ", $lastAuthorSeperator);
+      $lastAuthorSeperator = preg_replace("/ {2,}/", " ", $lastAuthorSeperator); // get rid of double spaces
     }
     $result .= $authors[count($authors)-2].$lastAuthorSeperator.$authors[count($authors)-1];
     return $result;

--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -170,8 +170,7 @@ if (defined('ENCODING')) {
 @define('USE_INITIALS_FOR_NAMES',false); // use only initials for all first names?
 @define('USE_FIRST_THEN_LAST',false); // put first names before last names?
 @define('FORCE_NAMELIST_SEPARATOR', ''); // if non-empty, use this to separate multiple names regardless of USE_COMMA_AS_NAME_SEPARATOR_IN_OUTPUT
-@define('LAST_AUTHOR_SEPARATOR',' and ');
-@define('USE_OXFORD_COMMA',false); // adds an additional separator in addition to LAST_AUTHOR_SEPARATOR if there are more than two authors
+@define('LAST_AUTHOR_SEPARATOR',' and '); // if there are more than 2 names, an Oxford comma will be used
 
 @define('TYPES_SIZE',10); // number of entry types per table
 @define('YEAR_SIZE',20); // number of years per table
@@ -1572,7 +1571,7 @@ class BibEntry {
       $result .= $authors[$i].$sep;
     }
     $lastAuthorSeperator = bibtexbrowser_configuration('LAST_AUTHOR_SEPARATOR');
-    if (count($authors)>2 && bibtexbrowser_configuration('USE_OXFORD_COMMA')) {
+    if (count($authors)>2) {
       $lastAuthorSeperator = $sep.$lastAuthorSeperator;
     }
     $result .= $authors[count($authors)-2].$lastAuthorSeperator.$authors[count($authors)-1];

--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -168,9 +168,10 @@ if (defined('ENCODING')) {
 // USE_FIRST_THEN_LAST => Herbert Meyer
 @define('USE_COMMA_AS_NAME_SEPARATOR_IN_OUTPUT',false);// output authors in a comma separated form, e.g. "Meyer, H"?
 @define('USE_INITIALS_FOR_NAMES',false); // use only initials for all first names?
-@define('USE_FIRST_THEN_LAST',false); // use only initials for all first names?
+@define('USE_FIRST_THEN_LAST',false); // put first names before last names?
 @define('FORCE_NAMELIST_SEPARATOR', ''); // if non-empty, use this to separate multiple names regardless of USE_COMMA_AS_NAME_SEPARATOR_IN_OUTPUT
 @define('LAST_AUTHOR_SEPARATOR',' and ');
+@define('USE_OXFORD_COMMA',false); // adds an additional separator in addition to LAST_AUTHOR_SEPARATOR if there are more than two authors
 
 @define('TYPES_SIZE',10); // number of entry types per table
 @define('YEAR_SIZE',20); // number of years per table
@@ -1562,7 +1563,11 @@ class BibEntry {
     for ($i=0;$i<count($authors)-2;$i++) {
       $result .= $authors[$i].$sep;
     }
-    $result .= $authors[count($authors)-2].bibtexbrowser_configuration('LAST_AUTHOR_SEPARATOR'). $authors[count($authors)-1];
+    $lastAuthorSeperator = bibtexbrowser_configuration('LAST_AUTHOR_SEPARATOR');
+    if (count($authors)>2 && bibtexbrowser_configuration('USE_OXFORD_COMMA')) {
+      $lastAuthorSeperator = $sep.$lastAuthorSeperator;
+    }
+    $result .= $authors[count($authors)-2].$lastAuthorSeperator.$authors[count($authors)-1];
     return $result;
   }
 


### PR DESCRIPTION
enables e.g. "Miroslaw Staron, Wilhelm Meding, and Christer Nilsson"  instead of "Miroslaw Staron, Wilhelm Meding and Christer Nilsson"