### PR TITLE
only display [pdf] if it is really a pdf, else use field name

### DIFF
--- a/bibtexbrowser-test.php
+++ b/bibtexbrowser-test.php
@@ -339,7 +339,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
   function test_link_configuration() {
     bibtexbrowser_configure('BIBTEXBROWSER_LINKS_TARGET','_self');
     $test_data = fopen('php://memory','x+');
-    fwrite($test_data, "@book{aKey,pdf={myarticle.pdf}}\n@book{bKey,url={myarticle.pdf}}\n@book{cKey,url={myarticle.htm}}\n"
+    fwrite($test_data, "@book{aKey,pdf={myarticle.pdf}}\n@book{bKey,url={myarticle.pdf}}\n@book{cKey,url={myarticle.xyz}}\n"
     );
     fseek($test_data,0);
     $btb = new BibDataBase();
@@ -352,7 +352,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
     $second_entry=$btb->bibdb[array_keys($btb->bibdb)[1]];
     $this->assertEquals('<a href="myarticle.pdf">[pdf]</a>',$second_entry->getPdfLink());
     $third_entry=$btb->bibdb[array_keys($btb->bibdb)[2]];
-    $this->assertEquals('<a href="myarticle.htm">[url]</a>',$third_entry->getPdfLink());
+    $this->assertEquals('<a href="myarticle.xyz">[url]</a>',$third_entry->getPdfLink());
   }
 
   // see https://github.com/monperrus/bibtexbrowser/pull/14

--- a/bibtexbrowser-test.php
+++ b/bibtexbrowser-test.php
@@ -339,7 +339,7 @@ class BTBTest extends PHPUnit_Framework_TestCase {
   function test_link_configuration() {
     bibtexbrowser_configure('BIBTEXBROWSER_LINKS_TARGET','_self');
     $test_data = fopen('php://memory','x+');
-    fwrite($test_data, "@book{aKey,pdf={myarticle.pdf}}\n"
+    fwrite($test_data, "@book{aKey,pdf={myarticle.pdf}}\n@book{bKey,url={myarticle.pdf}}\n@book{cKey,url={myarticle.htm}}\n"
     );
     fseek($test_data,0);
     $btb = new BibDataBase();
@@ -349,6 +349,10 @@ class BTBTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals('<a href="myarticle.pdf">[pdf]</a>',$first_entry->getPdfLink());
     $this->assertEquals('<a href="myarticle.pdf"><img class="icon" src="pdficon.png" alt="[pdf]" title="pdf"/></a>',$first_entry->getLink('pdf','pdficon.png'));
     $this->assertEquals('<a href="myarticle.pdf">[see]</a>',$first_entry->getLink('pdf',NULL,'see'));
+    $second_entry=$btb->bibdb[array_keys($btb->bibdb)[1]];
+    $this->assertEquals('<a href="myarticle.pdf">[pdf]</a>',$second_entry->getPdfLink());
+    $third_entry=$btb->bibdb[array_keys($btb->bibdb)[2]];
+    $this->assertEquals('<a href="myarticle.htm">[url]</a>',$third_entry->getPdfLink());
   }
 
   // see https://github.com/monperrus/bibtexbrowser/pull/14

--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -1346,7 +1346,7 @@ class BibEntry {
     $extension = strtolower(pathinfo(parse_url($this->getField($bibfield),PHP_URL_PATH),PATHINFO_EXTENSION));
     switch ($extension) {
       // overriding the label if it's a known extension
-      case 'html': return $this->getLink($bibfield, $iconurl, 'pdf'); break;
+      case 'html': return $this->getLink($bibfield, $iconurl, 'html'); break;
       case 'pdf': return $this->getLink($bibfield, $iconurl, 'pdf'); break;
       case 'ps': return $this->getLink($bibfield, $iconurl, 'ps'); break;
       default:

--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -1340,7 +1340,7 @@ class BibEntry {
     return "";
   }
 
-  /** See description of 'getPdfLink'
+  /** See description of 'getUrlLink'
     */
   function getAndRenameLink($bibfield, $iconurl=NULL) {
     $extension = strtolower(pathinfo(parse_url($this->getField($bibfield),PHP_URL_PATH),PATHINFO_EXTENSION));

--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -1317,7 +1317,7 @@ class BibEntry {
 
   /** kept for backward compatibility */
   function getPdfLink($iconurl = NULL, $label = NULL) {
-    return $this->getExtensionLink('pdf', $iconurl, $label);
+    return $this->getUrlLink($iconurl);
   }
 
   /** returns a "[pdf]" link for the entry, if possible.
@@ -1327,22 +1327,22 @@ class BibEntry {
     */
   function getUrlLink($iconurl = NULL) {
     if ($this->hasField('pdf')) {
-      return $this->getExtensionLink('pdf', $iconurl);
+      return $this->getAndRenameLink('pdf', $iconurl);
     }
     if ($this->hasField('url')) {
-      return $this->getExtensionLink('url', $iconurl);
+      return $this->getAndRenameLink('url', $iconurl);
     }
     // Adding link to PDF file exported by Zotero
     // ref: https://github.com/monperrus/bibtexbrowser/pull/14
     if ($this->hasField('file')) {
-      return $this->getExtensionLink('file', $iconurl);
+      return $this->getAndRenameLink('file', $iconurl);
     }
     return "";
   }
 
   /** See description of 'getPdfLink'
     */
-  function getExtensionLink($bibfield, $iconurl=NULL) {
+  function getAndRenameLink($bibfield, $iconurl=NULL) {
     $extension = strtolower(pathinfo(parse_url($this->getField($bibfield),PHP_URL_PATH),PATHINFO_EXTENSION));
     switch ($extension) {
       // overriding the label if it's a known extension

--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -1315,9 +1315,9 @@ class BibEntry {
     return $link;
   }
 
-  /** same as `getPdfLink`, kept for backward compatibility */
-  function getUrlLink($iconurl, $label) {
-    return $this->getPdfLink($iconurl, $label);
+  /** kept for backward compatibility */
+  function getPdfLink($iconurl = NULL, $label = NULL) {
+    return $this->getUrlLink($iconurl, $label);
   }
 
   /** returns a "[pdf]" link for the entry, if possible.
@@ -1325,7 +1325,7 @@ class BibEntry {
       Performs a sanity check that the file extension is 'pdf' or 'ps' and uses that as link label.
       Otherwise (and if no explicit $label is set) the field name is used instead.
     */
-  function getPdfLink($iconurl = NULL, $label = NULL) {
+  function getUrlLink($iconurl = NULL, $label = NULL) {
     if ($this->hasField('pdf')) {
       return $this->getExtensionLink('pdf', $iconurl, $label);
     }
@@ -1345,12 +1345,12 @@ class BibEntry {
   function getExtensionLink($bibfield, $iconurl=NULL, $altlabel=NULL) {
     $extension = strtolower(pathinfo(parse_url($this->getField($bibfield),PHP_URL_PATH),PATHINFO_EXTENSION));
     switch ($extension) {
-      case 'pdf': break;
-      case 'ps': break;
+      // overriding the label if it's a known extension
+      case 'pdf': return $this->getLink($bibfield, $iconurl, 'pdf'); break;
+      case 'ps': return $this->getLink($bibfield, $iconurl, 'ps'); break;
       default:
         return $this->getLink($bibfield, $iconurl, $altlabel);
     }
-    return $this->getLink($bibfield, NULL, $extension);
   }
 
 
@@ -2014,7 +2014,7 @@ function bib2links_default($bibentry) {
   }
 
   if (BIBTEXBROWSER_PDF_LINKS) {
-    $link = $bibentry->getPdfLink();
+    $link = $bibentry->getUrlLink();
     if ($link != '') { $links[] = $link; };
   }
 

--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -1317,7 +1317,7 @@ class BibEntry {
 
   /** kept for backward compatibility */
   function getPdfLink($iconurl = NULL, $label = NULL) {
-    return $this->getUrlLink($iconurl, $label);
+    return $this->getExtensionLink('pdf', $iconurl, $label);
   }
 
   /** returns a "[pdf]" link for the entry, if possible.
@@ -1325,31 +1325,32 @@ class BibEntry {
       Performs a sanity check that the file extension is 'pdf' or 'ps' and uses that as link label.
       Otherwise (and if no explicit $label is set) the field name is used instead.
     */
-  function getUrlLink($iconurl = NULL, $label = NULL) {
+  function getUrlLink($iconurl = NULL) {
     if ($this->hasField('pdf')) {
-      return $this->getExtensionLink('pdf', $iconurl, $label);
+      return $this->getExtensionLink('pdf', $iconurl);
     }
     if ($this->hasField('url')) {
-      return $this->getExtensionLink('url', $iconurl, $label);
+      return $this->getExtensionLink('url', $iconurl);
     }
     // Adding link to PDF file exported by Zotero
     // ref: https://github.com/monperrus/bibtexbrowser/pull/14
     if ($this->hasField('file')) {
-      return $this->getExtensionLink('file', $iconurl, $label);
+      return $this->getExtensionLink('file', $iconurl);
     }
     return "";
   }
 
   /** See description of 'getPdfLink'
     */
-  function getExtensionLink($bibfield, $iconurl=NULL, $altlabel=NULL) {
+  function getExtensionLink($bibfield, $iconurl=NULL) {
     $extension = strtolower(pathinfo(parse_url($this->getField($bibfield),PHP_URL_PATH),PATHINFO_EXTENSION));
     switch ($extension) {
       // overriding the label if it's a known extension
+      case 'html': return $this->getLink($bibfield, $iconurl, 'pdf'); break;
       case 'pdf': return $this->getLink($bibfield, $iconurl, 'pdf'); break;
       case 'ps': return $this->getLink($bibfield, $iconurl, 'ps'); break;
       default:
-        return $this->getLink($bibfield, $iconurl, $altlabel);
+        return $this->getLink($bibfield, $iconurl, $bibfield);
     }
   }
 


### PR DESCRIPTION
BIBTEXBROWSER_PDF_LINKS adds a [pdf] link no matter whether the field pdf/url/file really points to a PDF or not. My new option BIBTEXBROWSER_DOCUMENT_LINKS does a sanity check based on the file extension and if this is not .pdf uses the field name instead.
This version display all of the fields it finds (which I use if there is a publisher website but no DOI additionally to the PDF link)