### PR TITLE
Fix php82 deprecation warnings

### DIFF
--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -777,6 +777,10 @@ class XMLPrettyPrinter extends ParserDelegate {
 
 /** represents @string{k=v} */
 class StringEntry {
+  private string $name;
+  private string $value;
+  private string $filename;
+
   function __construct($k, $v, $filename) {
     $this->name=$k;
     $this->value=$v;

--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -777,9 +777,9 @@ class XMLPrettyPrinter extends ParserDelegate {
 
 /** represents @string{k=v} */
 class StringEntry {
-  private string $name;
-  private string $value;
-  private string $filename;
+  public $filename;
+  public $name;
+  public $value;
 
   function __construct($k, $v, $filename) {
     $this->name=$k;
@@ -3372,6 +3372,9 @@ usage:
 </pre>
   */
 class AcademicDisplay  {
+  public $db;
+  public $entries;
+  public $title;
 
   function getTitle() { return $this->title; }
   function setTitle($title) { $this->title = $title; return $this; }


### PR DESCRIPTION
Hi!

In PHP8.2, the dynamic declaration of class properties has been deprecated. See https://php.watch/versions/8.2/dynamic-properties-deprecated for some examples. This PR provides a fix to these warnings.