### PR TITLE
Fix XSS vulnerability.

### DIFF
--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -296,7 +296,8 @@ function default_message() {
   You may browse:<br/>
   <?php
   foreach (glob("*.bib") as $bibfile) {
-    $url="?bib=".$bibfile; echo '<a href="'.$url.'" rel="nofollow">'.$bibfile.'</a><br/>';
+    $url="?bib=".urlencode($bibfile);
+    echo '<a href="'.htmlspecialchars($url, ENT_QUOTES, 'UTF-8').'" rel="nofollow">'.htmlspecialchars($bibfile, ENT_QUOTES, 'UTF-8').'</a><br/>';
   }
   echo "</div>";
 }


### PR DESCRIPTION
**Description**
In my recent security analysis of bibtexbrowser script, I discovered a significant Stored Cross-Site Scripting (XSS) vulnerability. This flaw exists in the process of listing .bib files in the php script directory. The related function is default_message(), Line 288.

In the Line 299, the PHP script puts file name without proper neutralization or validation. This oversight allows an attacker to craft a malicious file name containing executable JavaScript code, which can then be stored on the server.

**Steps to reproduce**
1. Host a local server for the PHP script.
2. Create a file named `<img src=x onerror=alert('xss')>.bib` with the help of touch command in the Linux based OSes or use a python script for creating malicious files.
3. Go to `/bibtexbrowser.php?frameset&bib=` relative URL with the help of browser.

An alert message will appear on the page – malicious file name executed JavaScript code.

**PoC**
![image](https://github.com/user-attachments/assets/f92fd78b-c5f4-41fa-9e2c-1faed0cc97d2)

![image](https://github.com/user-attachments/assets/999afc16-3067-4382-9c58-a25eb102b092)

**Fix Implemented**
- Added `urlencode()` to encode the file names in the URL.
- Used `htmlspecialchars()` to escape special characters in the file names and URLs.

These changes prevent XSS vulnerabilities by ensuring that file names are safe to display and use.
